### PR TITLE
refactor: replace copy-paste with vscode clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,6 @@
 - Optional types
 - Array types
 
-## Known Issues
-
-`Command failed: xclip -selection clipboard -o`
-
----
-
-Solution: `sudo apt-get install xclip`
-
-Happens when linux is missing clipboard packages
-
 ## Links
 
 - [Repo](https://github.com/MariusAlch/vscode-json-to-ts)

--- a/package.json
+++ b/package.json
@@ -58,13 +58,11 @@
     "watch": "tsc -w -p ./"
   },
   "dependencies": {
-    "copy-paste": "^1.3.0",
     "json-to-ts": "^1.7.0",
     "universal-analytics": "^0.4.20",
     "uuid-by-string": "^3.0.2"
   },
   "devDependencies": {
-    "@types/copy-paste": "^1.1.30",
     "@types/node": "^10.5.2",
     "@types/universal-analytics": "0.3.27",
     "@types/vscode": "^1.38.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
 import * as path from "path";
 import * as os from "os";
 import * as fs from "fs";
-import { Uri, ExtensionContext, commands } from "vscode";
+import { Uri, ExtensionContext, commands, env } from "vscode";
 import JsonToTS from "json-to-ts";
 import {
   handleError,
-  getClipboardText,
   parseJson,
   pasteToMarker,
   getSelectedText,
@@ -32,7 +31,7 @@ function transformFromSelection() {
   const tmpFilePath = path.join(os.tmpdir(), "json-to-ts.ts");
   const tmpFileUri = Uri.file(tmpFilePath);
 
-  getSelectedText()
+  env.clipboard.readText()
     .then(logEvent(visitor, "Selection"))
     .then(validateLength)
     .then(parseJson)

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,6 +1,5 @@
 import { ViewColumn, window } from "vscode";
 import * as os from "os";
-import * as copyPaste from "copy-paste";
 import { Client } from "universal-analytics";
 import * as UuidByString from "uuid-by-string";
 
@@ -11,14 +10,6 @@ export function getUserId(): string {
 
   const str = [hostname, username, platform].join("--");
   return UuidByString(str);
-}
-
-export function getClipboardText() {
-  try {
-    return Promise.resolve(copyPaste.paste());
-  } catch (error) {
-    return Promise.reject(error);
-  }
 }
 
 export function handleError(error: Error) {


### PR DESCRIPTION
copy-paste has has cross-platform issues, it will depends on xclip. vscode has [clipboard api,](https://code.visualstudio.com/api/references/vscode-api#Clipboard) replace copy-paste with vscode clipboard.